### PR TITLE
chore: make placeholder consistent

### DIFF
--- a/src/DocSearchModalSearchBox.tsx
+++ b/src/DocSearchModalSearchBox.tsx
@@ -46,7 +46,7 @@ export const DocSearchModalSearchBox: Component<{
   translations = {},
 }) => {
   const {
-    searchDocsPlaceHolder = "Search docs",
+    searchDocsPlaceHolder = "Search",
     resetButtonTitle = "Clear the query",
     resetButtonAriaLabel = "Clear the query",
     cancelButtonText = "Cancel",


### PR DESCRIPTION
Make the placeholder in the search button the same as in the modal