### PR TITLE
docs: incorrect module import statements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then, insert `DocSearch` into it by calling the `docsearch` function and providi
 Make sure to provide a `container` (for example, a `div`), not an `input`. `DocSearch` generates a fully accessible search box for you.
 
 ```js
-import { docsearch } from "meilisearch-docsearch/js";
+import { docsearch } from "meilisearch-docsearch";
 import "meilisearch-docsearch/css";
 
 docsearch({


### PR DESCRIPTION
See:

https://github.com/tauri-apps/meilisearch-docsearch/blob/fa8ef47f37971309e20c74204a7b9ea6a2a52f02/package.json#L14-L19

There is no /js path configured in the exports.