### PR TITLE
Fix: Issue where the `command+k` shortcut cannot be triggered correctly on Mac. Adjusted the `meta` key detection logic to support Apple devices.

### DIFF
--- a/.changes/macos-meta.md
+++ b/.changes/macos-meta.md
@@ -1,5 +1,5 @@
 ---
-"meilisearch-docsearch": "patch:bug"
+"meilisearch-docsearch": "patch"
 ---
 
 Fix <kbd>Command</kbd>+<kbd>k</kbd> not working on macOS devices.

--- a/.changes/macos-meta.md
+++ b/.changes/macos-meta.md
@@ -1,0 +1,5 @@
+---
+"meilisearch-docsearch": "patch:bug"
+---
+
+Fix <kbd>Command</kbd>+<kbd>k</kbd> not working on macOS devices.

--- a/src/DocSearchModal.tsx
+++ b/src/DocSearchModal.tsx
@@ -317,10 +317,6 @@ export const DocSearchModal: Component<DocSearchModalProps> = ({
                             <a
                               href={hit.url || "#"}
                               aria-label={linkToTheResultAriaLabel}
-                              onClick={(e) => {
-                                // e.preventDefault();
-                                onClose && onClose();
-                              }}
                             >
                               <span class="docsearch-modal-search-hits-item-text-container">
                                 <p

--- a/src/DocSearchModal.tsx
+++ b/src/DocSearchModal.tsx
@@ -317,6 +317,10 @@ export const DocSearchModal: Component<DocSearchModalProps> = ({
                             <a
                               href={hit.url || "#"}
                               aria-label={linkToTheResultAriaLabel}
+                              onClick={(e) => {
+                                // e.preventDefault();
+                                onClose && onClose();
+                              }}
                             >
                               <span class="docsearch-modal-search-hits-item-text-container">
                                 <p

--- a/src/useDocSearchHotKeys.ts
+++ b/src/useDocSearchHotKeys.ts
@@ -59,7 +59,7 @@ export function useDocSearchHotKeys({
           const shift = event.shiftKey == modsAndkeys.includes("shift");
           const alt = event.altKey == modsAndkeys.some(isAlt);
           const meta =
-            !isAppleDevice() && event.metaKey == modsAndkeys.some(isMeta);
+            isAppleDevice() ? true : event.metaKey == modsAndkeys.some(isMeta);
 
           return ctrl && shift && alt && meta;
         }

--- a/src/useDocSearchHotKeys.ts
+++ b/src/useDocSearchHotKeys.ts
@@ -58,8 +58,9 @@ export function useDocSearchHotKeys({
             modsAndkeys.some(isCtrl);
           const shift = event.shiftKey == modsAndkeys.includes("shift");
           const alt = event.altKey == modsAndkeys.some(isAlt);
-          const meta =
-            isAppleDevice() ? true : event.metaKey == modsAndkeys.some(isMeta);
+          const meta = isAppleDevice()
+            ? true
+            : event.metaKey == modsAndkeys.some(isMeta);
 
           return ctrl && shift && alt && meta;
         }


### PR DESCRIPTION
### Fix #177 

- Fixed the issue where the `meta` key was not detected correctly on Mac, causing hotkeys to fail to trigger.