### PR TITLE
Add `checkCompositionEvent` option

### DIFF
--- a/.changes/check-composition-event.md
+++ b/.changes/check-composition-event.md
@@ -1,0 +1,5 @@
+---
+"meilisearch-docsearch": "minor"
+---
+
+Add `checkCompositionEvent` option to avoid unexpected input behaviour during IME composition.

--- a/src/DocSearch.tsx
+++ b/src/DocSearch.tsx
@@ -39,6 +39,7 @@ export interface DocSearchProps {
    * In the previous example, that would be `hello`.
    */
   debounceDuration?: number | false;
+  checkCompositionEvent?: boolean;
 }
 
 export type DocSearchTranslations = Partial<{

--- a/src/DocSearch.tsx
+++ b/src/DocSearch.tsx
@@ -39,6 +39,13 @@ export interface DocSearchProps {
    * In the previous example, that would be `hello`.
    */
   debounceDuration?: number | false;
+  /**
+   * Check composition event in `onKeyDown` for IME conmposition.
+   * Without this option, Enter for IME compoisiton triggers an unexpected search result selection.
+   * Set to `true` to fix this problem for CJKV and similar IME users.
+   *
+   * The default value is `false` to keep existing behavior.
+   */
   checkCompositionEvent?: boolean;
 }
 

--- a/src/DocSearchModal.tsx
+++ b/src/DocSearchModal.tsx
@@ -63,6 +63,7 @@ export const DocSearchModal: Component<DocSearchModalProps> = ({
   searchParams,
   environment = window,
   debounceDuration = 200,
+  checkCompositionEvent = false,
   translations = {},
   onClose,
   initialQuery,
@@ -107,6 +108,12 @@ export const DocSearchModal: Component<DocSearchModalProps> = ({
       target: Element;
     },
   ) {
+    // keyCode is deprecated but several documents recommend keyCode for this IME use case
+    // See: https://developer.mozilla.org/en-US/docs/Web/API/Element/keydown_event#keydown_events_with_ime
+    if (checkCompositionEvent && (e.isComposing || e.keyCode === 229)) {
+      return;
+    }
+
     // select previous/next item
     if (e.key === "ArrowUp" || e.key === "ArrowDown") {
       e.preventDefault();


### PR DESCRIPTION
I tried this cool project but I have run into a problem with Japanese IME.
See also: https://github.com/algolia/docsearch/issues/1304

I add `checkCompositionEvent` with default `false` to keep existing behavior.