### PR TITLE
feat: Optimize search requests with AbortController

### DIFF
--- a/.changes/abort-controller.md
+++ b/.changes/abort-controller.md
@@ -1,0 +1,5 @@
+---
+"meilisearch-docsearch": "patch"
+---
+
+Use AbortController to cancel outdated search requests, preventing race conditions and reducing unnecessary network usage.

--- a/src/DocSearchModal.tsx
+++ b/src/DocSearchModal.tsx
@@ -102,6 +102,14 @@ export const DocSearchModal: Component<DocSearchModalProps> = ({
   );
   const numberOfHits = () => hits().length;
 
+  // AbortController for cancelling previous search requests
+  let abortController: AbortController | null = null;
+
+  // Cancel ongoing requests when component unmounts
+  onCleanup(() => {
+    abortController?.abort();
+  });
+
   function onKeyDown(
     e: KeyboardEvent & {
       currentTarget: HTMLInputElement;
@@ -166,39 +174,66 @@ export const DocSearchModal: Component<DocSearchModalProps> = ({
     }
   }
 
-  function onReset() {
+  function resetState(screenState: ScreenState = ScreenState.EmptyQuery) {
     setLoading(false);
-    setScreenState(ScreenState.EmptyQuery);
+    setScreenState(screenState);
     setHits([]);
     setHitsCategories([]);
     setActiveItemIndex(0);
   }
 
+  function onReset() {
+    abortController?.abort();
+    abortController = null;
+    resetState();
+  }
+
   function search(query: string) {
+    if (abortController) abortController.abort();
+
+    abortController = new AbortController();
+    const currentController = abortController;
+
     setLoading(true);
     searchClient()
       .index(indexUid)
-      .search(query, {
-        attributesToHighlight: ["*"],
-        attributesToCrop: [`content`],
-        cropLength: 30,
-        ...searchParams,
-      })
+      .search(
+        query,
+        {
+          attributesToHighlight: ["*"],
+          attributesToCrop: [`content`],
+          cropLength: 30,
+          ...searchParams,
+        },
+        {
+          signal: abortController.signal,
+        },
+      )
       .catch((e) => {
-        onReset();
-        setScreenState(ScreenState.Error);
+        // Don't show error if request was aborted (user is still typing)
+        if (e.name === "AbortError") {
+          return;
+        }
+        // Check if this is still the current request before showing error
+        if (currentController.signal.aborted) {
+          return;
+        }
+        resetState(ScreenState.Error);
         console.error(e);
       })
       .then((res) => {
+        // Check if this request was cancelled
+        if (currentController.signal.aborted) {
+          return;
+        }
+
         if (!res) {
-          onReset();
-          setScreenState(ScreenState.Error);
+          resetState(ScreenState.Error);
           return;
         }
 
         if (res.hits.length === 0) {
-          onReset();
-          setScreenState(ScreenState.NoResults);
+          resetState(ScreenState.NoResults);
           return;
         }
 


### PR DESCRIPTION
## 🎯 Motivation

Currently, when users type quickly in the search box, multiple API requests 
are sent simultaneously. This can cause:
- Race conditions where stale responses override newer results
- Unnecessary load on the Meilisearch server
- Poor user experience with flickering results

## 🔧 Changes

- Add `AbortController` to cancel previous search requests when a new one starts
- Pass `signal` to the Meilisearch SDK search method (3rd parameter)
- Handle `AbortError` gracefully without showing error states
- Clean up ongoing requests when component unmounts
- Fix incorrect `onReset()` calls in error handlers that could cancel active requests

## ✅ Testing

Tested with:
- Network throttling (Slow 3G) to verify old requests are properly cancelled
- Rapid typing to confirm no race conditions occur
- Chrome DevTools Network tab shows "cancelled" status for aborted requests

## 📸 Screenshots
<img width="1278" height="414" alt="截圖 2025-12-29 上午11 33 02" src="https://github.com/user-attachments/assets/b80aca1a-1cfc-4dec-b954-86a2d553b8cc" />



---

Happy to make any adjustments based on feedback! 😊